### PR TITLE
Fix met annotations

### DIFF
--- a/model/g-thermo.xml
+++ b/model/g-thermo.xml
@@ -32,6 +32,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00030"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17499"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM24"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -93,6 +94,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06504"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27937"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM91520"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -116,6 +118,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C16255"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:80404"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6145"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -139,6 +142,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05336"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:9100"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM81829"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -162,6 +166,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15973"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:80219"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM96068"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -185,6 +190,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02737"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:11750 18303"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM221"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -208,6 +214,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15979"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:80224"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5588"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -231,6 +238,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02051"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15804"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM998"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -254,6 +262,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01242"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16882"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM81221"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -277,6 +286,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01094"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18105 37515"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM145568"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -406,6 +416,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C16255"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:80404"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6145"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -429,6 +440,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15972"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:80218"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM90032"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -452,6 +464,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C16254"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:80403"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5590"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -475,6 +488,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15973"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:80219"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM96068"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -498,6 +512,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00046"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18273"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM90337"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -521,6 +536,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00039"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16991"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM634"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -630,6 +646,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04088"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6439"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -681,6 +698,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C16220"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:80387"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6417"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -704,6 +722,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C16219"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:80386"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM10102"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -727,6 +746,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05764"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:5697"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM844"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -776,6 +796,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04633"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2576"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -799,6 +820,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05762"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:1639"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM4345"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -848,6 +870,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04688"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM7733"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -871,6 +894,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05761"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:50651"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM564"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -892,6 +916,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05223"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5723"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -944,6 +969,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05757"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:325"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM27066"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -967,6 +993,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05756"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:1637"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM28933"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -990,6 +1017,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05755"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:4349"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1473"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1038,6 +1066,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04619"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM7127"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1061,6 +1090,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05753"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:1634"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM26616"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1084,6 +1114,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05752"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:7725"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM979"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1131,6 +1162,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04620"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM10019"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1154,6 +1186,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05750"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:1646"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM28031"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1177,6 +1210,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05747"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:326"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM25370"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1200,6 +1234,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05749"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:5704"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM23683"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1223,6 +1258,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05746"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:1642"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM25602"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1270,6 +1306,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05745"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:3247"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2645"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1322,6 +1359,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00229"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18359"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM925"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1343,6 +1381,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/G01275"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1434"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1366,6 +1405,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15606"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:49252"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM494"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1389,6 +1429,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15651"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:50605"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM409"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1449,6 +1490,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00668"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17665"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM215"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1472,6 +1514,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00126"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16928"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM746"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1495,6 +1538,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00125"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15991"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5749"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1518,6 +1562,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06148"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28003"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM4269"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1615,6 +1660,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02972"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16194"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1663"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1638,6 +1684,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01235"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17505"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM878"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1661,6 +1708,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01213"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15465"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM608"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1720,6 +1768,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01077"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16288"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM699"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1741,6 +1790,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/G00289"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1142"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1772,6 +1822,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15980"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:80225"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM162399"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1795,6 +1846,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03589"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17655"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1176"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1969,6 +2021,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C17234"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18820"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1454"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -1990,6 +2043,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/G00501"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM61111"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2021,6 +2075,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05819"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18151"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM442"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2044,6 +2099,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05823"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28580"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6822"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2067,6 +2123,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05378"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28013"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM90006"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2090,6 +2147,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05399"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27527"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM61338"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2113,6 +2171,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02336"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28645"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1542"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2136,6 +2195,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02501"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:64037"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM162276"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2199,6 +2259,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01168"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18116"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2276"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2230,6 +2291,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05923"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:929"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2773"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2330,6 +2392,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04702"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:70768"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM7865"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2352,6 +2415,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05404"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27387 31005"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM61111"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2374,6 +2438,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05402"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28053"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1434"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2404,6 +2469,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05345"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16084"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM89621"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2427,6 +2493,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05922"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27985"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM53766"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2450,6 +2517,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00001"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15377"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2473,6 +2541,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02713"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:21615 28881"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2263"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2496,6 +2565,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02642"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18261"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM802"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2519,6 +2589,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00390"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17976"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM90307"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2582,6 +2653,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04322"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:1372"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1617"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2602,6 +2674,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/G10481"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM4897"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2632,6 +2705,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00399"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16389"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM90278"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2723,6 +2797,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/D05428"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM73253"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2746,6 +2821,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C17436"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:81087"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM7285"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2769,6 +2845,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C17437"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:81088"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM7288"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2792,6 +2869,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C17434"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:81085"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM7286"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2815,6 +2893,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C17435"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:81086"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM7283"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2838,6 +2917,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C17438"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:81089"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM7287"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2897,6 +2977,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05688"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16633"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM727"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2950,6 +3031,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06006"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27681 49256"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM114220"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -2973,6 +3055,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06002"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27821"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM933"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3031,6 +3114,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06007"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27512 49258"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1202"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3054,6 +3138,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C18902"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:77012"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM19347"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3077,6 +3162,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05759"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:1655"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM26095"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3100,6 +3186,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05401"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15754"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2608"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3123,6 +3210,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05400"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:4808"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM52342"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3185,6 +3273,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00682"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17236 67110"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1102"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3352,6 +3441,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00090"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18135"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM181"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3375,6 +3465,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C17556"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:60468"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM89653"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3398,6 +3489,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05993"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:37666"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM4377"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3421,6 +3513,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05983"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:62415"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5283"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3444,6 +3537,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05984"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:1148 50613"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM722772"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3467,6 +3561,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04122"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28390"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1697"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3498,6 +3593,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04051"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:2030"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM4388"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3521,6 +3617,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06320"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27513"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1496"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3542,6 +3639,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/G10495"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM60163"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3565,6 +3663,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02218"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17123"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM3414"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3588,6 +3687,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00429"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15901"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM506"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3611,6 +3711,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06416"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27630"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1588"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3634,6 +3735,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06408"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28629"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1589"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3657,6 +3759,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06407"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16430"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1441"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3680,6 +3783,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06406"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27711"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1291"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3703,6 +3807,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06399"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17926"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1279"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3726,6 +3831,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06505"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28531"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM92189"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3749,6 +3855,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06503"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27914"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1022"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3817,6 +3924,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05335"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:30021"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1676"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3840,6 +3948,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04144"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17420"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2563"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3922,6 +4031,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06506"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:2482"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM92086"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3945,6 +4055,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06507"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:2483"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM877"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -3998,6 +4109,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04272"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15684 49072"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM114097"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4054,6 +4166,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00819"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17061"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1819"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4077,6 +4190,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05772"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28307"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1290"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4100,6 +4214,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05768"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28607"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1322"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4123,6 +4238,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05766"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28766"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1123"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4201,6 +4317,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15667"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:48000"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1409"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4232,6 +4349,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00267"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17925"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM99"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4328,6 +4446,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02265"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16998"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2365"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4366,6 +4485,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15527"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:52469"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2152"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4388,6 +4508,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C11826"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:37790"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM88507"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4411,6 +4532,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C13378"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:32317"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5611"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4506,6 +4628,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05893"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27692"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1344"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4529,6 +4652,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00302"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18237"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM89557"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4552,6 +4676,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05699"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27760"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1837"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4605,6 +4730,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04778"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16837"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1224"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4628,6 +4754,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04823"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18319"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM607"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4651,6 +4778,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06319"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27858"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1497"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4716,6 +4844,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01542"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28054"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5247"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4739,6 +4868,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00617"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16085"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1092"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4827,6 +4957,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04509"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1721"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4850,6 +4981,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04501"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16446"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM340"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4873,6 +5005,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04507"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16046"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2633"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -4937,6 +5070,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00259"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17535"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM461"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5000,6 +5134,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01455"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17578"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM889"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5023,6 +5158,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01467"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17231"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2330"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5046,6 +5182,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01486"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29219"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2006"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5097,6 +5234,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05702"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:21969"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM65196"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5120,6 +5258,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05698"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:9096"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2562"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5143,6 +5282,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05703"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:64685"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5818"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5166,6 +5306,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04144"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17420"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2563"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5189,6 +5330,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03453"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:32808"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6068"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5212,6 +5354,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05116"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:37050"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM4337"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5235,6 +5378,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03028"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:9534"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1341"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5308,6 +5452,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00698"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17996"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM43"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5331,6 +5476,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04751"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28413"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM507"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5354,6 +5500,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05996"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:35819"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5646"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5442,6 +5589,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04752"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16629"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1135"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5465,6 +5613,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04807"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15998 73083"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1160"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5563,6 +5712,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04877"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:84805"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1446"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5769,6 +5919,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05125"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:978"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1705"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5910,6 +6061,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05258"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27402"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM825"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5933,6 +6085,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05259"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15491"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM738"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5956,6 +6109,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05260"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27466"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM767"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -5979,6 +6133,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05261"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28726"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM707"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -6002,6 +6157,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05262"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27668"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM733"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -6025,6 +6181,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05263"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27868"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM705"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -6048,6 +6205,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05264"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28325"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM674"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -6071,6 +6229,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05265"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28528"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM677"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -6094,6 +6253,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05266"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28632"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM766"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -6117,6 +6277,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05267"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28264"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM706"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -6140,6 +6301,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05268"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28276"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM757"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -6163,6 +6325,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05269"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27648"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM717"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -6186,6 +6349,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05270"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27540"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM553"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -6481,6 +6645,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05379"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:7815"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1289"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -6504,6 +6669,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05381"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:1463"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM3480"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -6619,6 +6785,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00124"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:4139"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM390"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -6691,6 +6858,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00125"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15991"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5749"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -6751,6 +6919,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05539"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17355"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1872"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -6774,6 +6943,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00126"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16928"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM746"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -7134,6 +7304,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05817"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:39564"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1249"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -7157,6 +7328,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05818"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28192"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM7001"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -7263,6 +7435,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05841"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27748"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1915"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -7286,6 +7459,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00138"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17513"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM169"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -7309,6 +7483,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05893"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27692"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1344"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -7360,6 +7535,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C11827"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:10151"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM94343"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -7383,6 +7559,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00139"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17908"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM178"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -7406,6 +7583,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05928"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27862"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM722924"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -7429,6 +7607,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00141"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:11851 16530"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM238"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -7482,6 +7661,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06019"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27973"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1659"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -7550,6 +7730,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06142"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28885"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM3230"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -7697,6 +7878,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06186"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18305"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2683"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -7870,6 +8052,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06441"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28566"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM59594"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -8195,6 +8378,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00163"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:30768"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM356"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -8471,6 +8655,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00170"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17509"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM150"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -8494,6 +8679,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C11355"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18198 35181"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1458"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -8517,6 +8703,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C11356"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:10698"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2473"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -8540,6 +8727,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C11434"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17764"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1626"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -8595,6 +8783,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C11435"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16578"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1642"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -8618,6 +8807,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C11436"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16840"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1641"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -8674,6 +8864,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C11453"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18425"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1168"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -8968,6 +9159,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C12147"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:37525"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1492"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -9039,6 +9231,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00196"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18026"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM455"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -9062,6 +9255,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00197"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17794"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM126"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -9163,6 +9357,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C14463"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:34008 49257"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM114594"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -9655,6 +9850,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15974"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:80220"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6824"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -9678,6 +9874,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15975"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:80221"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM163705"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -9701,6 +9898,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15976"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:48522"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6734"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -9724,6 +9922,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15977"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:80222"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5034"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -9747,6 +9946,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15978"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:80223"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6733"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -9770,6 +9970,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00221"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15903"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM105"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -9995,6 +10196,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00233"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:48430"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM404"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -10018,6 +10220,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00234"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15637"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM237"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -10041,6 +10244,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C16519"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:50271"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1861"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -10110,6 +10314,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00236"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16001"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM261"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -11097,6 +11302,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00288"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17544"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM60"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -11723,6 +11929,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00334"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16865"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM192"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -11825,6 +12032,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00345"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:48928"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM325"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -11848,6 +12056,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00349"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16256"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM305"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -12469,6 +12678,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00392"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16899"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM615"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -12729,6 +12939,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00430"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17549"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM405"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -12826,6 +13037,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00440"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15641"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM318"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -13891,6 +14103,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00542"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17755"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM7231"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -13950,6 +14163,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00555"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17769"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM422"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -14012,6 +14226,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00568"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:30753"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM421"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -14330,6 +14545,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00631"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17835"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM275"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -14549,6 +14765,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00666"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16026"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM644"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -14611,6 +14828,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00671"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15614"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM439"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -14634,6 +14852,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00672"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:11563 28542"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM789"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -14657,6 +14876,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00673"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16132 55513"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2179"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -14758,6 +14978,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00680"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16488 30308"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM529"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -14983,6 +15204,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00718"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28102"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM60163"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -15012,6 +15234,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/G10545"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1003"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -15169,6 +15392,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00826"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17530"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM696"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -15633,6 +15857,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00900"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16444"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM426"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -15727,6 +15952,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00944"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17947 32364"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM478"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -15794,6 +16020,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00966"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:11561 17094"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM959"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -16577,6 +16804,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01144"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15453"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM446"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -16717,6 +16945,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01179"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15999"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM153"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -16740,6 +16969,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01180"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:33574"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM276"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -16802,6 +17032,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01188"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:11805 18064"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM396"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -16963,6 +17194,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01236"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16938"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM429"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -17110,6 +17342,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01268"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18337"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1532"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -17133,6 +17366,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01269"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16257"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1365"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -17156,6 +17390,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01279"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16892"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM874"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -17208,6 +17443,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01300"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17083 44841"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM937"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -17270,6 +17506,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01302"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29112"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1455"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -17293,6 +17530,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01304"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29114 59546"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM648"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -17508,6 +17746,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01451"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17814"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2561"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -17859,6 +18098,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01929"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM4010"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -18149,6 +18389,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02323"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16464"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1855"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -18312,6 +18553,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02474"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:22590 28351"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6179"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -18389,6 +18631,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02504"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:1178 35128"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM985"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -18525,6 +18768,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02631"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17275"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1706"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -18548,6 +18792,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02637"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:30918"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM611"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -18847,6 +19092,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02923"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18404"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1064"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -18870,6 +19116,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00085"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15946 61553"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM162235"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19014,6 +19261,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03082"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15836"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1177"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19035,6 +19283,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03089"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1592"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19360,6 +19609,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03232"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:30933"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM541"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19454,6 +19704,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C20258"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM30985"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19477,6 +19728,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03344"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15476"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM524"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19500,6 +19752,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03345"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15478"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM609"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19634,6 +19887,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03479"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15640"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1392"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19657,6 +19911,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03492"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15905"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM415"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19680,6 +19935,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03506"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18299 51793"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM866"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -19960,6 +20216,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03912"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:371"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1617"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20110,6 +20367,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04030"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15572"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1978"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20133,6 +20391,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04039"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15689"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM734"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20300,6 +20559,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04171"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15941 48968"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM114261"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20396,6 +20656,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04181"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:11812 17667"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1638"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20419,6 +20680,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04188"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:27859"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM407"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20514,6 +20776,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04582"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28096"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM522"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20537,6 +20800,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04236"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:1467"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1602"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20607,6 +20871,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04294"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17957"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM962"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20699,6 +20964,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04327"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17857"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM960"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20798,6 +21064,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04352"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15769"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM483"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20858,6 +21125,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04390"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18317 49004"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1759"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20881,6 +21149,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04405"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15449"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM701"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20904,6 +21173,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04411"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:35121 43468"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM891"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -20965,6 +21235,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04454"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18247"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1178"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21059,6 +21330,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/G10518"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM4419"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21082,6 +21354,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04556"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18032"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM790"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21105,6 +21378,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00109"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:30831"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM159"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21160,6 +21434,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04618"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM91793"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21359,6 +21634,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04691"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18150"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1219"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21416,6 +21692,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04732"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15934"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM791"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -21844,6 +22121,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00001"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15377"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23635,6 +23913,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00267"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17925"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM99"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23658,6 +23937,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01641"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29175"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM90886"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23681,6 +23961,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01236"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16938"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM429"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23750,6 +24031,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00617"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16085"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1092"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23773,6 +24055,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00018"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18405"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM161"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23826,6 +24109,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00390"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17976"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM90307"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23849,6 +24133,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00010"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15346"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM12"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23872,6 +24157,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00143"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:1989"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM183"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23903,6 +24189,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15672"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:24480"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1278"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23926,6 +24213,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00019"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15414 67040"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM16"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23949,6 +24237,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00234"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15637"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM237"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -23972,6 +24261,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00024"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15351"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM21"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24034,6 +24324,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00003"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15846"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM8"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24091,6 +24382,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00440"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15641"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM318"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24114,6 +24406,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04574"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18197"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM326"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24137,6 +24430,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00004"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16908"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM10"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24206,6 +24500,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00005"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16474"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24229,6 +24524,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00006"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18009"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24252,6 +24548,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00083"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15531"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM40"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24275,6 +24572,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00101"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15635 20506"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM79"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24404,6 +24702,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02170"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:30860"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1572"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24427,6 +24726,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00682"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17236 67110"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1102"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24450,6 +24750,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C11838"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29484"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2449"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24473,6 +24774,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C06240"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:70738"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM97052"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24496,6 +24798,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15547"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:52668"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2306"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24519,6 +24822,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00683"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15466"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM89955"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24542,6 +24846,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05819"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18151"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM442"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24565,6 +24870,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05703"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:64685"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5818"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24588,6 +24894,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00750"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15746"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM408"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24611,6 +24918,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02323"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16464"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1855"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24634,6 +24942,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04144"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17420"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2563"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24657,6 +24966,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04631"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:68507"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1688"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24680,6 +24990,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04216"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17613"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1722"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24703,6 +25014,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00536"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18036 39949"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM332"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24726,6 +25038,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C11826"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:37790"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM88507"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24799,6 +25112,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02876"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:8478"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1499"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24822,6 +25136,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04734"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18381"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM456"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24845,6 +25160,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04051"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:2030"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM4388"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24868,6 +25184,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05996"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:35819"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5646"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24891,6 +25208,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03114"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15890"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1531"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24922,6 +25240,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00332"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15345"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM133"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -24945,6 +25264,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05336"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:9100"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM81829"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25024,6 +25344,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04144"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17420"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2563"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25047,6 +25368,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03479"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15640"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1392"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25070,6 +25392,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04181"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:11812 17667"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1638"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25139,6 +25462,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05766"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28766"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1123"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25162,6 +25486,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03194"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15675"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1029"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25185,6 +25510,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00894"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15513"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM650"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25208,6 +25534,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05768"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28607"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1322"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25291,6 +25618,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05198"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17319"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM316"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25314,6 +25642,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00302"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18237"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM89557"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25416,6 +25745,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00030"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17499"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM24"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25439,6 +25769,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02737"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:11750 18303"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM221"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25619,6 +25950,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00819"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:17061"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1819"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25642,6 +25974,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C02265"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16998"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2365"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25673,6 +26006,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00301"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16960"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM48596"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25696,6 +26030,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C15809"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:53647"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1984"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25719,6 +26054,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05823"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:28580"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6822"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25742,6 +26078,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00090"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18135"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM181"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25765,6 +26102,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C01486"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:29219"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2006"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25823,6 +26161,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00096"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15820"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM82"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25846,6 +26185,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04507"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16046"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM2633"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -25941,6 +26281,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00154"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15525"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM88"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26069,6 +26410,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04088"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM6439"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26092,6 +26434,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05764"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:5697"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM844"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26113,6 +26456,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04246"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM3229"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26136,6 +26480,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05755"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:4349"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1473"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26278,6 +26623,7 @@
               <bqbiol:is>
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05223"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM5723"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26301,6 +26647,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C04405"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15449"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM701"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26324,6 +26671,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C05759"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:1655"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM26095"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26540,6 +26888,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00046"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:18273"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM90337"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26563,6 +26912,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00039"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:16991"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM634"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26586,6 +26936,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C00356"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:15467"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM197"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>
@@ -26682,6 +27033,7 @@
                 <rdf:Bag>
                   <rdf:li rdf:resource="https://identifiers.org/kegg.compound/C03028"/>
                   <rdf:li rdf:resource="https://identifiers.org/chebi/CHEBI:9534"/>
+                  <rdf:li rdf:resource="https://identifiers.org/metanetx.chemical/MNXM1341"/>
                 </rdf:Bag>
               </bqbiol:is>
             </rdf:Description>

--- a/notebooks/2. Modifying metabolite annotations.ipynb
+++ b/notebooks/2. Modifying metabolite annotations.ipynb
@@ -339,7 +339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 14,
    "metadata": {
     "scrolled": true
    },
@@ -350,7 +350,7 @@
        "425"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -371,7 +371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -380,7 +380,7 @@
        "389"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -444,7 +444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 19,
    "metadata": {
     "scrolled": true
    },
@@ -455,7 +455,7 @@
        "37"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -503,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -512,7 +512,7 @@
        "59"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -535,12 +535,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are 59 metabolites without a CheBI ID annotated. "
+    "There are 59 metabolites without a CheBI ID annotated. Finally, we will try to add a MetanetX ID for the metabolites. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#save and commit\n",
+    "cobra.io.write_sbml_model(model,\"../model/g-thermo.xml\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#import\n",
+    "model = cobra.io.read_sbml_model(\"../model/g-thermo.xml\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -572,61 +592,61 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>553275</th>\n",
-       "      <td>slm:000010688</td>\n",
-       "      <td>MNXM266879</td>\n",
+       "      <th>812602</th>\n",
+       "      <td>slm:000143816</td>\n",
+       "      <td>MNXM423510</td>\n",
        "      <td>reference</td>\n",
-       "      <td>1-(5Z,8Z,11Z,14Z-eicosatetraenoyl)-2-(11-methy...</td>\n",
+       "      <td>1-O-hexadecyl-2-(13-methyltetradecanoyl)-3-(5Z...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>763959</th>\n",
-       "      <td>slm:000118654</td>\n",
-       "      <td>MNXM465303</td>\n",
-       "      <td>reference</td>\n",
-       "      <td>1-tridecanoyl-2-(11Z,14Z,17Z-eicoastrienoyl)-s...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1103006</th>\n",
-       "      <td>MNXM427977</td>\n",
-       "      <td>MNXM427977</td>\n",
+       "      <th>801140</th>\n",
+       "      <td>MNXM436446</td>\n",
+       "      <td>MNXM436446</td>\n",
        "      <td>identity</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1304116</th>\n",
-       "      <td>MNXM573009</td>\n",
-       "      <td>MNXM573009</td>\n",
+       "      <th>873481</th>\n",
+       "      <td>slm:000175024</td>\n",
+       "      <td>MNXM301072</td>\n",
+       "      <td>reference</td>\n",
+       "      <td>1-(8Z,11Z,14Z,17Z-eicosatetraenoyl)-2-(13-meth...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1071260</th>\n",
+       "      <td>MNXM312652</td>\n",
+       "      <td>MNXM312652</td>\n",
        "      <td>identity</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>418074</th>\n",
-       "      <td>lipidmaps:LMGP02010705</td>\n",
-       "      <td>MNXM71793</td>\n",
-       "      <td>reference</td>\n",
-       "      <td>1-(6Z,9Z,12Z-octadecatrienoyl)-2-docosanoyl-gl...</td>\n",
+       "      <th>1517721</th>\n",
+       "      <td>MNXM629889</td>\n",
+       "      <td>MNXM629889</td>\n",
+       "      <td>identity</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                          #XREF      MNX_ID   Evidence  \\\n",
-       "553275            slm:000010688  MNXM266879  reference   \n",
-       "763959            slm:000118654  MNXM465303  reference   \n",
-       "1103006              MNXM427977  MNXM427977   identity   \n",
-       "1304116              MNXM573009  MNXM573009   identity   \n",
-       "418074   lipidmaps:LMGP02010705   MNXM71793  reference   \n",
+       "                 #XREF      MNX_ID   Evidence  \\\n",
+       "812602   slm:000143816  MNXM423510  reference   \n",
+       "801140      MNXM436446  MNXM436446   identity   \n",
+       "873481   slm:000175024  MNXM301072  reference   \n",
+       "1071260     MNXM312652  MNXM312652   identity   \n",
+       "1517721     MNXM629889  MNXM629889   identity   \n",
        "\n",
        "                                               Description  \n",
-       "553275   1-(5Z,8Z,11Z,14Z-eicosatetraenoyl)-2-(11-methy...  \n",
-       "763959   1-tridecanoyl-2-(11Z,14Z,17Z-eicoastrienoyl)-s...  \n",
-       "1103006                                                NaN  \n",
-       "1304116                                                NaN  \n",
-       "418074   1-(6Z,9Z,12Z-octadecatrienoyl)-2-docosanoyl-gl...  "
+       "812602   1-O-hexadecyl-2-(13-methyltetradecanoyl)-3-(5Z...  \n",
+       "801140                                                 NaN  \n",
+       "873481   1-(8Z,11Z,14Z,17Z-eicosatetraenoyl)-2-(13-meth...  \n",
+       "1071260                                                NaN  \n",
+       "1517721                                                NaN  "
       ]
      },
-     "execution_count": 28,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -639,16 +659,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "35"
+       "37"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -675,12 +695,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are: 35 metabolites without Kegg, 57 without CheBI and 35 without MetanetX ID. Lets see if there is overlap between these lists, and if so if there are any metabolites with no annotations. "
+    "There are: 37 metabolites without Kegg, 59 without CheBI and 37 without MetanetX ID. Lets see if there is overlap between these lists, and if so if there are any metabolites with no annotations. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -692,16 +712,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "35"
+       "37"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -720,16 +740,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "35"
+       "37"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -743,55 +763,57 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These 35 metabolites without kegg and metanetX thus also do not have a CheBI ID assigned to them. Let's inspect them and decide if we should add these manually. "
+    "These 37 metabolites without kegg and metanetX thus also do not have a CheBI ID assigned to them. Let's inspect them and decide if we should add these manually. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<Metabolite myinp_c at 0x20e20b5d988>,\n",
-       " <Metabolite uamagdgll_c at 0x20e20b5f6c8>,\n",
-       " <Metabolite sucrose_c at 0x20e20b63d88>,\n",
-       " <Metabolite pant_c at 0x20e20b68048>,\n",
-       " <Metabolite maltose_c at 0x20e20b68508>,\n",
-       " <Metabolite ftethplg_c at 0x20e20b6c388>,\n",
-       " <Metabolite homocarn_c at 0x20e20b6c648>,\n",
-       " <Metabolite isomalt_c at 0x20e20b6cf48>,\n",
-       " <Metabolite carsine_c at 0x20e20b71348>,\n",
-       " <Metabolite treh6p_c at 0x20e20b731c8>,\n",
-       " <Metabolite rpantholcys_c at 0x20e20b80488>,\n",
-       " <Metabolite focytB561_c at 0x20e20b87108>,\n",
-       " <Metabolite capra_c at 0x20e20b8c988>,\n",
-       " <Metabolite bdxyl_c at 0x20e20b8e708>,\n",
-       " <Metabolite sus6p_c at 0x20e20b8ea48>,\n",
-       " <Metabolite a4oxopent_c at 0x20e20b97248>,\n",
-       " <Metabolite xylan_c at 0x20e20b9b4c8>,\n",
-       " <Metabolite epimelbio_c at 0x20e20b9b7c8>,\n",
-       " <Metabolite abmaagapc_c at 0x20e20ba2b88>,\n",
-       " <Metabolite naneura_c at 0x20e20bea348>,\n",
-       " <Metabolite raff_c at 0x20e20c06788>,\n",
-       " <Metabolite betaine_c at 0x20e20c1d108>,\n",
-       " <Metabolite ino1p_c at 0x20e20c30608>,\n",
-       " <Metabolite Biomass_c at 0x20e20c72488>,\n",
-       " <Metabolite succcoa_c at 0x20e20c8b048>,\n",
-       " <Metabolite glc6P_e at 0x20e20c93408>,\n",
-       " <Metabolite Biomass_e at 0x20e20c95248>,\n",
-       " <Metabolite betaine_e at 0x20e20c9c348>,\n",
-       " <Metabolite uamagdgll_e at 0x20e20c9f5c8>,\n",
-       " <Metabolite capra_e at 0x20e20ca1448>,\n",
-       " <Metabolite acetol_e at 0x20e20ca1508>,\n",
-       " <Metabolite ftethplg_e at 0x20e20ca4588>,\n",
-       " <Metabolite abmaagapc_e at 0x20e20caa288>,\n",
-       " <Metabolite a4oxopent_e at 0x20e20cac308>,\n",
-       " <Metabolite acon_e at 0x20e20cb12c8>]"
+       "[<Metabolite myinp_c at 0x269d280a688>,\n",
+       " <Metabolite uamagdgll_c at 0x269d2806848>,\n",
+       " <Metabolite sucrose_c at 0x269d2801188>,\n",
+       " <Metabolite pant_c at 0x269d27fd208>,\n",
+       " <Metabolite maltose_c at 0x269d774a8c8>,\n",
+       " <Metabolite ftethplg_c at 0x269d27f4d88>,\n",
+       " <Metabolite homocarn_c at 0x269d27f5688>,\n",
+       " <Metabolite isomalt_c at 0x269d27efd08>,\n",
+       " <Metabolite carsine_c at 0x269d27e5f08>,\n",
+       " <Metabolite treh6p_c at 0x269d27dd288>,\n",
+       " <Metabolite rpantholcys_c at 0x269d27b14c8>,\n",
+       " <Metabolite focytB561_c at 0x269d27a7ac8>,\n",
+       " <Metabolite capra_c at 0x269d2794c08>,\n",
+       " <Metabolite bdxyl_c at 0x269d278fd08>,\n",
+       " <Metabolite sus6p_c at 0x269d278ee48>,\n",
+       " <Metabolite a4oxopent_c at 0x269d2772788>,\n",
+       " <Metabolite xylan_c at 0x269d276b9c8>,\n",
+       " <Metabolite epimelbio_c at 0x269d276b748>,\n",
+       " <Metabolite malt6p2_c at 0x269d276c808>,\n",
+       " <Metabolite Glycan_2_c at 0x269d276bf48>,\n",
+       " <Metabolite abmaagapc_c at 0x269d2758b48>,\n",
+       " <Metabolite naneura_c at 0x269d3a13748>,\n",
+       " <Metabolite raff_c at 0x269d36ca108>,\n",
+       " <Metabolite betaine_c at 0x269d3640308>,\n",
+       " <Metabolite ino1p_c at 0x269d6eb7ac8>,\n",
+       " <Metabolite Biomass_c at 0x269d79e6c88>,\n",
+       " <Metabolite succcoa_c at 0x269d72a2808>,\n",
+       " <Metabolite glc6P_e at 0x269d7289808>,\n",
+       " <Metabolite Biomass_e at 0x269d7285c08>,\n",
+       " <Metabolite betaine_e at 0x269d7069c08>,\n",
+       " <Metabolite uamagdgll_e at 0x269d705fb08>,\n",
+       " <Metabolite capra_e at 0x269d705fa08>,\n",
+       " <Metabolite acetol_e at 0x269d7056c48>,\n",
+       " <Metabolite ftethplg_e at 0x269d70551c8>,\n",
+       " <Metabolite abmaagapc_e at 0x269d70349c8>,\n",
+       " <Metabolite a4oxopent_e at 0x269d6e266c8>,\n",
+       " <Metabolite acon_e at 0x269d6e116c8>]"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -805,16 +827,16 @@
    "metadata": {},
    "source": [
     "# Conclusion\n",
-    "There are still 35 metabolites without anny annotation. These appear to be more distant metabolites and so maybe we can leave them without annotations. As in general they still have names, so if needed one can search them in a general databse or search engine. "
+    "There are still 37 metabolites without any annotation. These appear to be more distant metabolites and so maybe we can leave them without annotations. As in general they still have names, so if needed one can search them in a general databse or search engine. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
-    "cobra.io.write_sbml_model(model,'../model/Beata_model_orig_g-thermo.xml')"
+    "cobra.io.write_sbml_model(model,'../model/g-thermo.xml')"
    ]
   }
  ],


### PR DESCRIPTION
In this branch I supplied the metabolites with annotations. Overall, only 37 metabolites now remain without annotations, but as these seem quite distant and may be removed later anyway this is deemed acceptable for now, as we will likely review them again later anyway. 