### PR TITLE
chore: cobra update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ Both the cobra and cameo dependencies are required for operation of the g-thermo
 NOTE: Please pip install the following version of cobrapy (temporal):
 
 ```bash
-pip install git+git://github.com/BenjaSanchez/cobrapy.git@fix/switch-group-type --upgrade
+pip install git+git://github.com/opencobra/cobrapy.git@devel --upgrade
 ```


### PR DESCRIPTION
cobrapy has merged to their development branch the changes that fixed the group shuffling: https://github.com/opencobra/cobrapy/pull/927

No new release yet though, and as their development has been slow lately, in the meantime we can switch to their development version. I tested it and as expected does not shuffle any reaction group.