### PR TITLE
fix SBML error

### DIFF
--- a/model/g-thermo.xml
+++ b/model/g-thermo.xml
@@ -50991,16 +50991,14 @@
           </rdf:RDF>
         </annotation>
         <listOfReactants>
-          <speciesReference species="M_h2o_c" stoichiometry="2" constant="true"/>
-          <speciesReference species="M_nad_c" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_betald_c" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_h2o_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_betald_c" stoichiometry="1" constant="true"/>
           <speciesReference species="M_nadp_c" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
-          <speciesReference species="M_nadh_c" stoichiometry="1" constant="true"/>
           <speciesReference species="M_nadph_c" stoichiometry="1" constant="true"/>
-          <speciesReference species="M_h_c" stoichiometry="4" constant="true"/>
-          <speciesReference species="M_glyb_c" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_h_c" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_glyb_c" stoichiometry="1" constant="true"/>
         </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_BETALDHy" sboTerm="SBO:0000176" id="R_BETALDHy" name="Betaine-aldehyde dehydrogenase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
@@ -51024,6 +51022,16 @@
             </rdf:Description>
           </rdf:RDF>
         </annotation>
+        <listOfReactants>
+          <speciesReference species="M_h2o_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_betald_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_nadp_c" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="M_nadph_c" stoichiometry="1" constant="true"/>
+          <speciesReference species="M_h_c" stoichiometry="2" constant="true"/>
+          <speciesReference species="M_glyb_c" stoichiometry="1" constant="true"/>
+        </listOfProducts>
       </reaction>
       <reaction metaid="meta_R_NADN" sboTerm="SBO:0000176" id="R_NADN" name="NAD nucleosidase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
         <annotation>

--- a/notebooks/37. Orphan metabolites.ipynb
+++ b/notebooks/37. Orphan metabolites.ipynb
@@ -330,7 +330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1960,11 +1960,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.reactions.BETALDHx.add_metabolites({\n",
+    "model.reactions.BETALDHy.add_metabolites({\n",
     "    model.metabolites.betald_c:-1,\n",
     "    model.metabolites.h2o_c:-1,\n",
     "    model.metabolites.nadp_c:-1,\n",
@@ -2192,7 +2192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 174,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
Here I fixed the BETALDHx and BETALDHy reactions as i saw the SBML validator was giving me an error., as BETALDHy had no reactants. Looking back into my notebook 37 I saw a typo that added the reactants double to the BETALDH reactions and not to the BETALDHy reaction. So i fix that here and hope it solved the issue.