### PR TITLE
fix ACSERT bounds

### DIFF
--- a/model/g-thermo.xml
+++ b/model/g-thermo.xml
@@ -43574,7 +43574,7 @@
           <fbc:geneProductRef fbc:geneProduct="G_RTMO12345"/>
         </fbc:geneProductAssociation>
       </reaction>
-      <reaction metaid="meta_R_ACSERT" sboTerm="SBO:0000176" id="R_ACSERT" name="O3-acetyl-L-serine:L-homocysteine S-(2-amino-2-carboxyethyl)transferase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_default_ub">
+      <reaction metaid="meta_R_ACSERT" sboTerm="SBO:0000176" id="R_ACSERT" name="O3-acetyl-L-serine:L-homocysteine S-(2-amino-2-carboxyethyl)transferase" reversible="false" fast="false" fbc:lowerFluxBound="cobra_0_bound" fbc:upperFluxBound="cobra_0_bound">
         <annotation>
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
             <rdf:Description rdf:about="#meta_R_ACSERT">

--- a/model/g-thermo.yml
+++ b/model/g-thermo.yml
@@ -32392,8 +32392,8 @@
       - cyst__L_c: 1.0
       - h_c: 1.0
       - hcys__L_c: -1.0
-    - lower_bound: 0.0
-    - upper_bound: 1000.0
+    - lower_bound: 0
+    - upper_bound: 0
     - gene_reaction_rule: RTMO12345
     - annotation: !!omap
       - ec-code: 2.5.1.134


### PR DESCRIPTION
In this PR, I investigated and checked a few things in the cysteine biosynthesis. I saw that in our model, cysteine was synthesized via methionine. From literature (e.g. Hullo et al., 2007 doi:10.1128/JB.01273-06) the ACSERT reaction we had in the model, condensing homocysteine with acetyl-serine is only active when methionine is the sole sulfur source. As that is not the case in our model, I've artificially blocked this reaction by setting the bounds to (0,0).
Then cysteine biosynthesis was restored as expected. Methionine is made from homocysteine. However, in the model, homocysteine is generated somewhat differently than is included in E. coli. It resembles hcys formation more in the B. subtilis model, which would be expected. 